### PR TITLE
remove "Matlab" from a few other configurations/customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ENGR 101 Matlab Runestone
+# ENGR 101 Runestone
 
 This repository contains the runestone "book" with ENGR 101 lectures and exercises.
 

--- a/conf.py
+++ b/conf.py
@@ -46,7 +46,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'ENGR 101 Matlab'
+project = 'ENGR 101'
 copyright = '2020 jamesjuett'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -121,7 +121,7 @@ html_theme = 'sphinx_bootstrap'
 #html_theme_options = {'nosidebar': 'true'}
 html_theme_options = {
     # Navigation bar title. (Default: ``project`` value)
-    'navbar_title': "ENGR 101 Matlab",
+    'navbar_title': "ENGR 101",
 
     # Tab name for entire site. (Default: "Site")
     'navbar_site_name': "Chapters",
@@ -166,10 +166,10 @@ html_theme_options = {
 html_theme_path = [pkg_resources.resource_filename('runestone', 'common/project_template/_templates/plugin_layouts')]
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "ENGR 101 Matlab"
+html_title = "ENGR 101"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-html_short_title = "ENGR 101 Matlab"
+html_short_title = "ENGR 101"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.

--- a/sphinx_settings.json
+++ b/sphinx_settings.json
@@ -1,1 +1,1 @@
-{"SPHINX_SOURCE_PATH": "_sources", "SPHINX_OUT_PATH": "build/engr101matlab"}
+{"SPHINX_SOURCE_PATH": "_sources", "SPHINX_OUT_PATH": "build/engr101umich"}


### PR DESCRIPTION
(Since we're re-branding the book to appropriately reflect that it's not specifically matlab.)