### PR TITLE
Fix #8

### DIFF
--- a/_sources/functions_and_data/main.rst
+++ b/_sources/functions_and_data/main.rst
@@ -5,6 +5,7 @@
 .. raw:: html
 
    <link rel="stylesheet" href="../_static/common/css/matlab.css">
+   <script src="../_static/common/js/common.js"></script>
    <script src="../_static/common/js/matcrab-exercises.bundle.js"></script>
 
 ==================

--- a/_sources/intro_to_matlab/main.rst
+++ b/_sources/intro_to_matlab/main.rst
@@ -2,6 +2,10 @@
    :prefix: Q
    :start: 1
 
+.. raw:: html
+
+   <script src="../_static/common/js/common.js"></script>
+
 ======================
 Introduction to MATLAB
 ======================

--- a/_sources/logical_indexing/main.rst
+++ b/_sources/logical_indexing/main.rst
@@ -5,6 +5,7 @@
 .. raw:: html
 
    <link rel="stylesheet" href="../_static/common/css/matlab.css">
+   <script src="../_static/common/js/common.js"></script>
    <script src="../_static/common/js/matcrab-exercises.bundle.js"></script>
 
 ===============================

--- a/_sources/vectors_and_matrices/main.rst
+++ b/_sources/vectors_and_matrices/main.rst
@@ -5,6 +5,7 @@
 .. raw:: html
 
    <link rel="stylesheet" href="../_static/common/css/matlab.css">
+   <script src="../_static/common/js/common.js"></script>
    <script src="../_static/common/js/matcrab-exercises.bundle.js"></script>
 
 ====================


### PR DESCRIPTION
This PR fixes #8 by adding the `common.js` script to the earliest chapters that were written before we added that script. (The `common.js` script is our place to put anything we want to run on every chapter, and is currently just used for a small number of things like hiding the "number of activities" completed message at the bottom that was confusing/misleading for students.)