### PR TITLE
Fix theme-overrides.css getting unincluded

### DIFF
--- a/_static/common/css/theme-overrides.css
+++ b/_static/common/css/theme-overrides.css
@@ -17,6 +17,7 @@
   --codeButtonsBorder: #474949;
   --dangerAlerts: #f2dede;
   --successAlerts: #dff0d8;
+  --componentBgColor: 
 }
 
 .journal > form > fieldset > legend {
@@ -143,4 +144,9 @@ blockquote {
 .admonition-danger {
   background-color: #f8d7da;
   border-color: #f5c6cb;
+}
+
+/* Add overrides for runestone component css here */
+.runestone {
+  
 }

--- a/conf.py
+++ b/conf.py
@@ -232,3 +232,5 @@ html_show_sourcelink = False
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'PythonCoursewareProjectdoc'
 
+# custom files in _static
+setup.custom_css_files = ['common/css/theme-overrides.css']


### PR DESCRIPTION
This fixes a long-standing issue where our custom css in `theme-overrides.css` was no longer being included. The breaking change that caused this was in https://github.com/RunestoneInteractive/RunestoneComponents/pull/1233.

Now the same file is included via configuration options in `conf.py`.

This should fix a number of regressions:
 - Random boilerplate runestone things like exercise IDs will be hidden again.
 - Custom spacing fixes we had applied are back.
 - Adds back in some custom styling for Matcrab

@lslavice 
You can also override the weird new css for the `.runestone` component here at the bottom of the `_static/common/css/theme-overrides.css` file. It looks like the defaults were changed to include increased padding, margins, background-color, and the thick borders. If you want to get rid of all of those, you could change it to:

```css
.runestone {
  background-color: transparent;
  border-style: none;
  margin-top: 0;
  margin-bottom: 0;
  padding: 0;
}
```

