### PR TITLE
typos and .erase()

### DIFF
--- a/_sources/logical_indexing/main.rst
+++ b/_sources/logical_indexing/main.rst
@@ -82,6 +82,10 @@ We've seen that MATLAB supports arithmetic operations (e.g. :code:`+`, :code:`.*
 
   Relational operators return a **logical** result (either :code:`true` or :code:`false`). True is often encoded as 1, and false is often encoded as 0. Relational operators work on matrices, as well as scalars.
 
+  **Typos:**
+
+  - On slide 4, the expression :code:`4>=5` is :code:`false` so the boolean value should be :code:`0` not :code:`1`. 
+
    
 
 --------------------------------------------

--- a/_sources/more_data_structures/main.rst
+++ b/_sources/more_data_structures/main.rst
@@ -751,6 +751,24 @@ Complete the :code:`sum` function in the :file:`analyzeData.cpp` file. Here is t
       :width: 560
       :align: center
 
+    |
+    
+    Note: there is a typo in this video.
+
+    .. code-block:: cpp
+
+       for (int i=0; i < vecs/size(); ++i){
+
+    should be 
+
+    .. code-block:: cpp
+
+       for (int i=0; i < vecs.size(); ++i){
+
+
+
+
+
 ------------------
 Analyzing the Data
 ------------------

--- a/_sources/program_design_in_cpp/main.rst
+++ b/_sources/program_design_in_cpp/main.rst
@@ -234,6 +234,10 @@ One more thing before we move on... we just made some very useful functions, but
 
    **Unit testing** is the practice of testing each function individually to make sure it behaves as it should according to its **interface**. We often do this using the :code:`assert` function, which ends the program with an error message if its input is not true. A good way to organize unit tests is to write them in a separate file with its own :code:`main` function.
 
+   **Typos:**
+
+   - The slides say that :code:`assert` is a built-in MATLAB function. It is also a built-in C++ function.  
+
 --------------------------
 Exercise: Unit Testing
 --------------------------
@@ -451,7 +455,7 @@ In the next few videos, we'll use top-down design to clean up our proof-of-conce
 
 .. note::
 
-   There's actually two minor mistakes in the files that we've given you. If you look closely, you'll see that we forgot to include `std::` for some keywords in the in the `.h` files (including `document.h`). Additionally, in `encryptDocument.cpp`, we mistakenly put `using namespace std;` before `#include "document.h"`. That's not the correct ordering (all includes should come first), but coincidentally it cancels out the mistake of not having the `std::` in `document.h` insofar as it's included in `encryptDocument.cpp`. This will be fixed in future iterations of our textbook!
+   There's actually two minor mistakes in the files that we've given you. If you look closely, you'll see that we forgot to include :code:`std::` for some keywords in the in the :code:`.h` files (including :code:`document.h`). Additionally, in :code:`encryptDocument.cpp`, we mistakenly put :code:`using namespace std;` before :code:`#include "document.h"`. That's not the correct ordering (all includes should come first), but coincidentally it cancels out the mistake of not having the :code:`std::` in :code:`document.h` insofar as it's included in :code:`encryptDocument.cpp`. This will be fixed in future iterations of our textbook!
 
 
 We identified two new functions that we need to implement: :code:`loadDocument()` and :code:`writeDocument()`. Let's add these functions in a new module, :code:`document.cpp` and :code:`document.h`.

--- a/_sources/strings_and_cells/main.rst
+++ b/_sources/strings_and_cells/main.rst
@@ -150,6 +150,10 @@ Let's consider indexing into cell arrays:
 
   The :code:`cell2mat` function creates a regular array from a cell array containing numbers. The :code:`num2cell` function does the reverse - it creates a cell array from a regular array of numbers.
 
+  **Typos:**
+
+  - On slides 13 and 14, the array :code:`[2 3 4]` should be :code:`[1 2 3]`. (We copied the wrong array in the slides, sorry about that!)
+
 -----------------------------
 Exercise: Cell Array Practice
 -----------------------------

--- a/_sources/strings_streams_and_io/main.rst
+++ b/_sources/strings_streams_and_io/main.rst
@@ -396,6 +396,25 @@ There's more ways that we can use the :code:`replace` function. Open up the `doc
 
     + Correct! According to the documentation, A value of ``string::npos`` indicates all characters until the end of the string.
 
+
+----------------
+:code:`.erase()`
+----------------
+
+The :code:`erase` function takes two arguments: an integer :code:`pos` and an integer :code:`len`. The :code:`erase` function goes into the string at index :code:`pos` and removes :code:`len` characters. Consider these examples:
+
+.. raw:: html
+
+   <div class="lobster-ex" style="width: 600px; margin-left: auto; margin-right: auto">
+      <div class="lobster-ex-project-name">ch16_sample_erase</div>
+   </div>
+
+Try changing the values for :code:`pos` and :code:`len` and observe which characters are erased in the string.
+
+
+
+
+
 ------------------
 :code:`.substr()`
 ------------------

--- a/_sources/tables/main.rst
+++ b/_sources/tables/main.rst
@@ -10,9 +10,9 @@
 
    <script src="../_static/common/js/common3.js"></script>
 
-======
-Tables
-======
+=============
+MATLAB Tables
+=============
 
 .. admonition:: Chapter Files
 

--- a/_sources/tables/toctree.rst
+++ b/_sources/tables/toctree.rst
@@ -1,8 +1,8 @@
-Tables
-::::::
+MATLAB Tables
+:::::::::::::
 
 .. toctree::
-  :caption: Tables
+  :caption: MATLAB Tables
   :maxdepth: 4
 
   main.rst

--- a/_sources/vectors_in_cpp/main.rst
+++ b/_sources/vectors_in_cpp/main.rst
@@ -718,7 +718,7 @@ As we saw with some of the MATLAB programs, sometimes we want to know the index 
 
 .. code-block:: cpp
 
-   // Returns the value of the minimum element in the vector
+   // Returns the index of the maximum element in the vector
    int index_of_max_element(const vector<int> &vec) {
    
    // first, check to see if this is an empty vector; if the vector

--- a/_static/common/css/theme-overrides.css
+++ b/_static/common/css/theme-overrides.css
@@ -149,7 +149,8 @@ blockquote {
 /* Add overrides for runestone component css here */
 .runestone {
   background-color: transparent;
-  border-style: none;
+  border-width: 1px;
+  border-color: #cccccc;
   margin-top: 0;
   margin-bottom: 0;
   padding: 0;

--- a/_static/common/js/lobster-exercises14.bundle.js
+++ b/_static/common/js/lobster-exercises14.bundle.js
@@ -60755,6 +60755,50 @@ int main() {
             })
         ]
     },
+    "ch16_sample_erase": {
+        starterCode: `#include <iostream>
+#include <string>
+using namespace std;
+
+int main() {
+  // remove characters starting at the beginning of the string
+  string chant = "Hail to the victors valiant";
+  chant.erase(0, 12);
+  cout << chant; // will print "victors valiant"
+  cout << endl;
+
+  // remove characters starting at the beginning of the string
+  chant = "Hail to the victors valiant";
+  chant.erase(0, 8);
+  cout << chant; // will print "the victors valiant"
+  cout << endl;
+
+  // remove characters from the middle of the string
+  chant = "Hail to the victors valiant";
+  chant.erase(12, 8);
+  cout << chant; // will print "Hail to the valiant"
+  cout << endl;
+
+  // remove characters from the end of the string
+  chant = "Hail to the victors valiant";
+  chant.erase(12, 25); // len is too large for the end of the string
+                       // so the rest of the string is removed
+  cout << chant; // will print "Hail to the "
+  cout << endl;
+
+  // remove characters from the end of the string
+  chant = "Hail to the victors valiant";
+  chant.erase(5, chant.npos);  // use npos to remove all remaining
+                                // characters in the string
+  cout << chant; // will print "Hail"
+  cout << endl;
+}`,
+    checkpoints: [
+        new checkpoints_1.OutputCheckpoint("Correct Output", (output) => {
+            return output === "victors valiant\nthe victors valiant\nHail to the valiant\nHail to the\nHail";
+        })
+    ]
+    },
     "ch16_ex_printDoubled": {
         starterCode: `#include <iostream>
 #include <vector>


### PR DESCRIPTION
Added some notes on typos. Added in a section on the .erase() function for strings in C++. It has a lobster exercise, but I don't know if it will work correctly. Need to see what happens after a rebuild.